### PR TITLE
Update DumpTools.c

### DIFF
--- a/src/DumpTools.c
+++ b/src/DumpTools.c
@@ -642,7 +642,7 @@ BOOL MiniDumpWriteDumpA(HANDLE hProcess, DWORD pid, HANDLE hFile, struct fPtrs* 
     if (!fetch_process_info(&dc, function_ptrs)) return FALSE;
 
     fetch_modules_info(&dc, function_ptrs);
-    nStreams = 3;
+    nStreams = 6;
     nStreams = (nStreams + 3) & ~3;
 
     // Write Header


### PR DESCRIPTION
On Windows 11 there is a problem that most times the dumping code does not work when compiled to PIC.

The fix is to set nstreams to 6 instead of 3.

With this fix Handlekatz should work again for Win11 :).